### PR TITLE
[TASK] 지원하기 페이지 연봉순, 마감순 sort 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -81,7 +81,6 @@ function App(): JSX.Element {
       <Switch>
         <Route exact path={RecruitNav} component={Footer} />
       </Switch>
-      <Footer />
     </BrowserRouter>
   );
 }

--- a/src/components/UI/organisms/ApplyNavBar.tsx
+++ b/src/components/UI/organisms/ApplyNavBar.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from "react";
 import styled from "styled-components";
 import { observer } from "mobx-react";
-
+import { useLocation } from "react-router-dom";
 import QuantityLabel, { Text, Box } from "../atoms/Labels/QuantityLabel";
 import theme from "../../../styles/theme";
 
@@ -10,9 +10,13 @@ import { MenuProps } from "../../../models/applyInterfaces";
 
 const ApplyNav = styled.ul`
   display: flex;
-  justify-content: flex-start;
+  justify-content: space-between;
   align-items: center;
   padding: 40px 0;
+`;
+
+const Boxs = styled.div`
+  display: flex;
 `;
 
 const PositionName = styled.span`
@@ -25,21 +29,17 @@ const PositionList = styled.li`
   display: flex;
   align-items: center;
   cursor: pointer;
-
   & + li {
     padding-left: 24px;
   }
-
   ${PositionName} {
     color: ${theme.color.mainDeep};
     transition: color 0.3s;
   }
-
   ${Box} {
     background-color: ${theme.color.mainDeep};
     transition: background-color 0.3s;
   }
-
   ${Text} {
     color: ${theme.color.white};
     transition: color 0.3s;
@@ -50,16 +50,36 @@ const NonePositionList = styled.li`
   display: flex;
   align-items: center;
   cursor: pointer;
-
   & + li {
     padding-left: 24px;
   }
+`;
+
+const Sort = styled.div`
+  font-size: 14px;
+  display: flex;
+  cursor: pointer;
+
+  span {
+    font-size: 14px;
+    font-weight: 400;
+    color: ${theme.color.grey2};
+  }
+`;
+
+const SortText = styled.div`
+  font-size: 14px;
+  margin: 0px 16px;
+  color: ${props =>
+    props.isActive ? `${theme.color.black}` : `${theme.color.grey2}`};
+  font-weight: ${props => (props.isActive ? 700 : 400)};
 `;
 
 const ApplyNavBar = observer((): JSX.Element => {
   const department = ["전체", "개발", "디자인", "마케팅"];
   const { ApplyMenuStore } = RootStore();
   const { clicked, totalContent } = ApplyMenuStore;
+  const location = useLocation();
 
   useEffect(() => {
     const setDepartment = (arr: any) => {
@@ -73,32 +93,95 @@ const ApplyNavBar = observer((): JSX.Element => {
     }
   }, [ApplyMenuStore.clicked]);
 
+  useEffect(() => {
+    const date = (a: any, b: any) => {
+      if (a.deadline > b.deadline) {
+        return -1;
+      }
+      if (a.deadline < b.deadline) {
+        return 1;
+      }
+      return 0;
+    };
+
+    const salary = (a: any, b: any) => {
+      if (a.maximum_salary > b.maximum_salary) {
+        return -1;
+      }
+      if (a.maximum_salary < b.maximum_salary) {
+        return 1;
+      }
+      return 0;
+    };
+
+    if (ApplyMenuStore.clicked === "마감순") {
+      ApplyMenuStore.setViewContent(totalContent.sort(date));
+    } else if (ApplyMenuStore.clicked === "인기순") {
+      ApplyMenuStore.setViewContent(totalContent);
+    } else if (ApplyMenuStore.clicked === "연봉순") {
+      ApplyMenuStore.setViewContent(totalContent.sort(salary));
+    }
+  }, [ApplyMenuStore.clicked]);
+
   return (
     <ApplyNav>
-      {department.map(item => {
-        const IsActive = item === clicked ? PositionList : NonePositionList;
-        return (
-          <IsActive
-            key={item}
+      <Boxs>
+        {department.map(item => {
+          const IsActive = item === clicked ? PositionList : NonePositionList;
+          return (
+            <IsActive
+              key={item}
+              onClick={() => {
+                ApplyMenuStore.setClicked(item);
+              }}
+            >
+              <PositionName>{item}</PositionName>
+              {item === "전체" ? (
+                <QuantityLabel quantity={ApplyMenuStore.totalContent.length} />
+              ) : (
+                <QuantityLabel
+                  quantity={
+                    ApplyMenuStore.totalContent.filter(function (
+                      el: MenuProps
+                    ) {
+                      return el.position === item;
+                    }).length
+                  }
+                />
+              )}
+            </IsActive>
+          );
+        })}
+      </Boxs>
+      {location.pathname === "/recruit/apply" && (
+        <Sort>
+          <SortText
             onClick={() => {
-              ApplyMenuStore.setClicked(item);
+              ApplyMenuStore.setClicked("마감순");
+            }}
+            isActive={ApplyMenuStore.clicked === "마감순"}
+          >
+            마감순
+          </SortText>
+          <span>|</span>
+          {/* <SortText
+            onClick={() => {
+              ApplyMenuStore.setClicked("인기순");
             }}
           >
-            <PositionName>{item}</PositionName>
-            {item === "전체" ? (
-              <QuantityLabel quantity={ApplyMenuStore.totalContent.length} />
-            ) : (
-              <QuantityLabel
-                quantity={
-                  ApplyMenuStore.totalContent.filter(function (el: MenuProps) {
-                    return el.position === item;
-                  }).length
-                }
-              />
-            )}
-          </IsActive>
-        );
-      })}
+            인기순
+          </SortText>
+          <span>|</span> */}
+          <SortText
+            onClick={() => {
+              ApplyMenuStore.setClicked("연봉순");
+            }}
+            isActive={ApplyMenuStore.clicked === "연봉순"}
+          >
+            연봉순
+          </SortText>
+        </Sort>
+      )}
     </ApplyNav>
   );
 });

--- a/src/components/templates/AdminNotiUpload.tsx
+++ b/src/components/templates/AdminNotiUpload.tsx
@@ -23,6 +23,22 @@ const Box = styled.section`
   overflow-y: scroll;
   background: ${theme.color.white};
   padding-top: 100px;
+
+  ul {
+    li {
+      list-style: inside;
+      margin-left: 10px;
+      line-height: 1.5;
+    }
+  }
+
+  ol {
+    li {
+      list-style: decimal;
+      margin-left: 30px;
+      line-height: 1.5;
+    }
+  }
 `;
 
 const HeaderWrap = styled.header`

--- a/src/styles/globalStyle.ts
+++ b/src/styles/globalStyle.ts
@@ -24,22 +24,7 @@ const GlobalStyle = createGlobalStyle`
     font-style: italic;
   }
 
-  ul {
-    li { 
-     list-style: inside;
-     margin-left: 10px;
-     line-height: 1.5;
-    }
-  }
-  
-  ol {
-    li {
-     list-style: decimal;
-     margin-left: 30px;
-     line-height: 1.5;
-   }
-  }
-  
+
 h1 {
   font-size: 30px;
   font-weight: 900;


### PR DESCRIPTION
**Description**
필수 리뷰어:

---
# 진행 배경
## 작업 목표
- 채용공고 지원하기 페이지에 마감순 연봉순 인기순 sort 추가 작업실시 
---

# 결과
## 변경 후
- 인기순은 데이터가 없어서 구현하지 않고 마감순 연봉순만 추가하였습니다.
---

# 어려웠던 점
- 
---

# 레퍼런스
-  어드민 페이지는 아니지만  백엔드에서 추가 요청이 들어와서 기능 구현 하였습니다. 
---
# 기타
![sort](https://user-images.githubusercontent.com/77542039/134535154-2d0e781b-a3cc-4e9a-803d-2bee322e2f78.png)

